### PR TITLE
feat: AWS S3 연동 및 사진 업로드/조회/삭제 기능 구현

### DIFF
--- a/src/main/java/com/uijae/moments/album/entity/Album.java
+++ b/src/main/java/com/uijae/moments/album/entity/Album.java
@@ -1,23 +1,26 @@
 package com.uijae.moments.album.entity;
 
-import com.uijae.moments.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.util.StringUtils;
 
 @Table(name = "album")
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Album {
 
   @Setter
@@ -39,10 +42,11 @@ public class Album {
   @Column(updatable = false)
   private LocalDate createdDate;
 
-  @Setter
-  @ManyToOne
-  @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+  // S3 테스트를 위해 잠시 제외 (DB 포함)
+//  @Setter
+//  @ManyToOne
+//  @JoinColumn(name = "user_id", nullable = false)
+//  private User user;
 
   @PrePersist
   public void prePersist() {

--- a/src/main/java/com/uijae/moments/album/image/entity/AlbumImage.java
+++ b/src/main/java/com/uijae/moments/album/image/entity/AlbumImage.java
@@ -9,13 +9,19 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Table(name = "album_image")
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AlbumImage {
 
   @Id

--- a/src/main/java/com/uijae/moments/album/image/repository/AlbumImageRepository.java
+++ b/src/main/java/com/uijae/moments/album/image/repository/AlbumImageRepository.java
@@ -1,0 +1,10 @@
+package com.uijae.moments.album.image.repository;
+
+import com.uijae.moments.album.image.entity.AlbumImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlbumImageRepository extends JpaRepository<AlbumImage, Long> {
+
+}

--- a/src/main/java/com/uijae/moments/album/repository/AlbumRepository.java
+++ b/src/main/java/com/uijae/moments/album/repository/AlbumRepository.java
@@ -1,0 +1,10 @@
+package com.uijae.moments.album.repository;
+
+import com.uijae.moments.album.entity.Album;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlbumRepository extends JpaRepository<Album, Long> {
+
+}

--- a/src/main/java/com/uijae/moments/album/s3/config/AwsS3Config.java
+++ b/src/main/java/com/uijae/moments/album/s3/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.uijae.moments.album.s3.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+  @Value("${aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${aws.s3.region}")
+  private String region;
+
+  // 배포 하기 전 고정 -> 동적 인증 변경 예정
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKey, secretKey)))
+        .build();
+  }
+}

--- a/src/main/java/com/uijae/moments/album/s3/controller/AwsS3Controller.java
+++ b/src/main/java/com/uijae/moments/album/s3/controller/AwsS3Controller.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +23,7 @@ public class AwsS3Controller {
 
   // 이미지 업로드
   @Operation(summary = "이미지 업로드", description = "여러 개의 파일을 업로드하고, 업로드된 이미지 ID 목록을 반환합니다.")
-  @PostMapping("/upload")
+  @PostMapping("/files")
   public ResponseEntity<List<Long>> uploadFiles(@RequestParam("files") List<MultipartFile> files,
       @RequestParam("albumId") Long albumId) {
 
@@ -33,16 +34,16 @@ public class AwsS3Controller {
 
   // 이미지 URL 조회
   @Operation(summary = "이미지 다운로드", description = "이미지 ID를 통해 S3 URL을 가져옵니다.")
-  @GetMapping("/download")
-  public ResponseEntity<String> getFileUrl(@RequestParam("imageId") Long imageId) {
+  @GetMapping("/{imageId}")
+  public ResponseEntity<String> getFileUrl(@PathVariable Long imageId) {
 
     return ResponseEntity.ok(awsS3Service.getFileUrl(imageId));
   }
 
   // 이미지 삭제
   @Operation(summary = "이미지 삭제", description = "이미지 ID를 이용해 S3에서 파일을 삭제합니다.")
-  @DeleteMapping("/delete")
-  public ResponseEntity<Void> deleteFile(@RequestParam("imageId") Long imageId) {
+  @DeleteMapping("/{imageId}")
+  public ResponseEntity<Void> deleteFile(@PathVariable Long imageId) {
 
     awsS3Service.deleteFile(imageId);
 

--- a/src/main/java/com/uijae/moments/album/s3/controller/AwsS3Controller.java
+++ b/src/main/java/com/uijae/moments/album/s3/controller/AwsS3Controller.java
@@ -1,0 +1,51 @@
+package com.uijae.moments.album.s3.controller;
+
+import com.uijae.moments.album.s3.service.AwsS3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/s3")
+@RequiredArgsConstructor
+public class AwsS3Controller {
+
+  private final AwsS3Service awsS3Service;
+
+  // 이미지 업로드
+  @Operation(summary = "이미지 업로드", description = "여러 개의 파일을 업로드하고, 업로드된 이미지 ID 목록을 반환합니다.")
+  @PostMapping("/upload")
+  public ResponseEntity<List<Long>> uploadFiles(@RequestParam("files") List<MultipartFile> files,
+      @RequestParam("albumId") Long albumId) {
+
+    List<Long> imageIds = awsS3Service.uploadFiles(files, albumId);
+
+    return ResponseEntity.ok(imageIds);
+  }
+
+  // 이미지 URL 조회
+  @Operation(summary = "이미지 다운로드", description = "이미지 ID를 통해 S3 URL을 가져옵니다.")
+  @GetMapping("/download")
+  public ResponseEntity<String> getFileUrl(@RequestParam("imageId") Long imageId) {
+
+    return ResponseEntity.ok(awsS3Service.getFileUrl(imageId));
+  }
+
+  // 이미지 삭제
+  @Operation(summary = "이미지 삭제", description = "이미지 ID를 이용해 S3에서 파일을 삭제합니다.")
+  @DeleteMapping("/delete")
+  public ResponseEntity<Void> deleteFile(@RequestParam("imageId") Long imageId) {
+
+    awsS3Service.deleteFile(imageId);
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/uijae/moments/album/s3/service/AwsS3Service.java
+++ b/src/main/java/com/uijae/moments/album/s3/service/AwsS3Service.java
@@ -1,0 +1,124 @@
+package com.uijae.moments.album.s3.service;
+
+import com.uijae.moments.album.entity.Album;
+import com.uijae.moments.album.image.entity.AlbumImage;
+import com.uijae.moments.album.image.repository.AlbumImageRepository;
+import com.uijae.moments.album.repository.AlbumRepository;
+import com.uijae.moments.common.exception.CustomException;
+import static com.uijae.moments.common.exception.ErrorCode.ALBUM_NOT_FOUND;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_DELETE_FAILED;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_IS_EMPTY;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_UPLOAD_FAILED;
+import static com.uijae.moments.common.exception.ErrorCode.IMAGE_NOT_FOUND;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+  private final S3Client s3Client;
+  private final AlbumImageRepository albumImageRepository;
+  private final AlbumRepository albumRepository;
+
+  @Value("${aws.s3.bucket-name}")
+  private String bucketName;
+
+  // 여러 개의 파일 업로드
+  public List<Long> uploadFiles(List<MultipartFile> files, Long albumId) {
+    log.info("파일 업로드 요청 - albumId: {}, 파일 개수: {}", albumId, files.size());
+
+    Album album = albumRepository.findById(albumId)
+        .orElseThrow(() -> new CustomException(ALBUM_NOT_FOUND));
+
+    List<Long> imageIds = new ArrayList<>();
+
+    for (MultipartFile file : files) {
+      if (file.isEmpty()) {
+        throw new CustomException(FILE_IS_EMPTY);
+      }
+
+      String filename = file.getOriginalFilename();
+      String s3Key = UUID.randomUUID() + "_" + filename;
+
+      // S3에 업로드
+      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+          .bucket(bucketName)
+          .key(s3Key)
+          .build();
+
+      try {
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+      } catch (IOException e) {
+        log.error("파일 업로드 실패 - S3에 업로드하는 중 오류 발생", e);
+        throw new CustomException(FILE_UPLOAD_FAILED);
+      }
+
+      String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucketName, s3Key);
+      log.info("S3 업로드 성공 - URL: {}", fileUrl);
+
+      // DB 데이터 저장
+      AlbumImage albumImage = AlbumImage.builder()
+          .url(fileUrl)
+          .album(album)
+          .build();
+
+      AlbumImage savedImage = albumImageRepository.save(albumImage);
+      log.info("DB 저장 완료 - imageId: {}", savedImage.getId());
+
+      imageIds.add(savedImage.getId());
+    }
+
+    return imageIds;
+  }
+
+  // ID로 파일 URL 조회
+  public String getFileUrl(Long imageId) {
+    AlbumImage albumImage = getImage(imageId);
+
+    return albumImage.getUrl();
+  }
+
+  // ID로 파일 삭제
+  public void deleteFile(Long imageId) {
+    AlbumImage albumImage = getImage(imageId);
+
+    String fileKey = albumImage.getUrl().substring(albumImage.getUrl().lastIndexOf("/") + 1);
+
+    try {
+      // S3에서 삭제
+      s3Client.deleteObject(DeleteObjectRequest.builder()
+          .bucket(bucketName)
+          .key(fileKey)
+          .build());
+    } catch (S3Exception e) {
+      log.error("파일 삭제 실패 - S3에서 삭제하는 중 오류 발생", e);
+      throw new CustomException(FILE_DELETE_FAILED);
+    }
+
+    // DB 데이터 삭제
+    albumImageRepository.delete(albumImage);
+    log.info("이미지 삭제 완료 - imageId: {}, fileKey: {}", imageId, fileKey);
+  }
+
+  private AlbumImage getImage(Long imageId) {
+    return albumImageRepository.findById(imageId)
+        .orElseThrow(() -> {
+          log.error("이미지를 찾을 수 없음 - imageId: {}", imageId);
+          return new CustomException(IMAGE_NOT_FOUND);
+        });
+  }
+}

--- a/src/main/java/com/uijae/moments/common/exception/CustomException.java
+++ b/src/main/java/com/uijae/moments/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.uijae.moments.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getDetail());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/uijae/moments/common/exception/ErrorCode.java
+++ b/src/main/java/com/uijae/moments/common/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.uijae.moments.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+  // 파일 관련 에러
+  FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다."),
+  FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제 중 오류가 발생했습니다."),
+  FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "파일이 비어있습니다."),
+
+  // 앨범 관련 에러
+  ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "앨범을 찾을 수 없습니다."),
+
+  // 이미지 관련 에러
+  IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+  ;
+
+  private final HttpStatus status;
+  private final String detail;
+
+  ErrorCode(HttpStatus status, String detail) {
+    this.status = status;
+    this.detail = detail;
+  }
+}

--- a/src/main/java/com/uijae/moments/common/exception/ExceptionController.java
+++ b/src/main/java/com/uijae/moments/common/exception/ExceptionController.java
@@ -1,0 +1,31 @@
+package com.uijae.moments.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionController {
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ExceptionResponse> handleCustomException(CustomException e) {
+    log.warn("API Exception -> {}", e.getErrorCode());
+
+    return ResponseEntity
+        .status(e.getErrorCode().getStatus())
+        .body(new ExceptionResponse(e.getMessage(), e.getErrorCode()));
+  }
+
+  @Getter
+  @ToString
+  @AllArgsConstructor
+  public static class ExceptionResponse {
+    private String message;
+    private ErrorCode errorCode;
+  }
+}

--- a/src/main/java/com/uijae/moments/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/uijae/moments/common/swagger/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.uijae.moments.common.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Moments API")
+            .version("0.0.1")
+            .description("Moments API Documentation"));
+  }
+}

--- a/src/test/java/com/uijae/moments/album/s3/service/AwsS3ServiceTest.java
+++ b/src/test/java/com/uijae/moments/album/s3/service/AwsS3ServiceTest.java
@@ -1,0 +1,280 @@
+package com.uijae.moments.album.s3.service;
+
+import com.uijae.moments.album.entity.Album;
+import com.uijae.moments.album.image.entity.AlbumImage;
+import com.uijae.moments.album.image.repository.AlbumImageRepository;
+import com.uijae.moments.album.repository.AlbumRepository;
+import com.uijae.moments.common.exception.CustomException;
+import static com.uijae.moments.common.exception.ErrorCode.ALBUM_NOT_FOUND;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_DELETE_FAILED;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_IS_EMPTY;
+import static com.uijae.moments.common.exception.ErrorCode.FILE_UPLOAD_FAILED;
+import static com.uijae.moments.common.exception.ErrorCode.IMAGE_NOT_FOUND;
+import java.util.List;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+
+@ExtendWith(MockitoExtension.class)
+class AwsS3ServiceTest {
+
+  @Mock
+  private S3Client s3Client;
+
+  @Mock
+  private AlbumImageRepository albumImageRepository;
+
+  @Mock
+  private AlbumRepository albumRepository;
+
+  @InjectMocks
+  private AwsS3Service awsS3Service;
+
+  @Test
+  @DisplayName("앨범 ID에 여러 개의 이미지를 업로드하면, 저장된 이미지 ID 목록을 반환해야 한다.")
+  void uploadFiles_success() {
+    // given
+    List<MultipartFile> mockFiles = List.of(
+        new MockMultipartFile("test1.jpg", "test1.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}),
+        new MockMultipartFile("test2.jpg", "test2.jpg", "image/jpeg", new byte[]{5, 6, 7, 8})
+    );
+
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album title")
+        .summary("test album summary")
+        .type("test type")
+        .build();
+
+    when(albumRepository.findById(anyLong())).thenReturn(Optional.of(mockAlbum));
+
+    // Mock S3Client 동작
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(null);
+
+    // Mock AlbumImage 저장 동작
+    AlbumImage mockAlbumImage1 = new AlbumImage();
+    mockAlbumImage1.setId(100L);
+    mockAlbumImage1.setAlbum(mockAlbum);
+
+    AlbumImage mockAlbumImage2 = new AlbumImage();
+    mockAlbumImage2.setId(101L);
+    mockAlbumImage2.setAlbum(mockAlbum);
+
+    when(albumImageRepository.save(any(AlbumImage.class)))
+        .thenReturn(mockAlbumImage1, mockAlbumImage2);
+
+    // when
+    List<Long> imageIds = awsS3Service.uploadFiles(mockFiles, 1L);
+
+    // then
+    assertNotNull(imageIds);
+    assertEquals(2, imageIds.size());
+    assertTrue(imageIds.contains(100L));
+    assertTrue(imageIds.contains(101L));
+    verify(albumImageRepository, times(2)).save(any(AlbumImage.class));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 앨범 ID로 요청하면, ALBUM_NOT_FOUND 예외가 발생해야 한다.")
+  void uploadFiles_fail_album_not_found() {
+    // given
+    List<MultipartFile> mockFiles = List.of(
+        new MockMultipartFile("test1.jpg", "test1.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}),
+        new MockMultipartFile("test2.jpg", "test2.jpg", "image/jpeg", new byte[]{5, 6, 7, 8})
+    );
+
+    when(albumRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class,
+        () -> awsS3Service.uploadFiles(mockFiles, 1L));
+
+    assertEquals(ALBUM_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("파일 리스트 중 하나라도 비어 있으면, FILE_IS_EMPTY 예외가 발생해야 한다.")
+  void uploadFiles_fail_file_is_empty() {
+    // given
+    List<MultipartFile> mockFiles = List.of(
+        new MockMultipartFile("test1.jpg", "test1.jpg", "image/jpeg", new byte[0]),
+        new MockMultipartFile("test2.jpg", "test2.jpg", "image/jpeg", new byte[]{5, 6, 7, 8})
+    );
+
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album")
+        .build();
+
+    when(albumRepository.findById(anyLong())).thenReturn(Optional.of(mockAlbum));
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class,
+        () -> awsS3Service.uploadFiles(mockFiles, 1L));
+
+    assertEquals(FILE_IS_EMPTY, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("S3 업로드 중 오류가 발생하면, FILE_UPLOAD_FAILED 예외가 발생해야 한다.")
+  void uploadFiles_fail_file_upload_failed() {
+    List<MultipartFile> mockFiles = List.of(
+        new MockMultipartFile("test1.jpg", "test1.jpg", "image/jpeg", new byte[]{1, 2, 3, 4}),
+        new MockMultipartFile("test2.jpg", "test2.jpg", "image/jpeg", new byte[]{5, 6, 7, 8})
+    );
+
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album title")
+        .summary("test album summary")
+        .type("test type")
+        .build();
+
+    when(albumRepository.findById(anyLong())).thenReturn(Optional.of(mockAlbum));
+
+    AlbumImage mockAlbumImage1 = new AlbumImage();
+    mockAlbumImage1.setId(100L);
+    mockAlbumImage1.setAlbum(mockAlbum);
+
+    AlbumImage mockAlbumImage2 = new AlbumImage();
+    mockAlbumImage2.setId(101L);
+    mockAlbumImage2.setAlbum(mockAlbum);
+
+    doThrow(new CustomException(FILE_UPLOAD_FAILED))
+        .when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class,
+        () -> awsS3Service.uploadFiles(mockFiles, 1L));
+
+    assertEquals(FILE_UPLOAD_FAILED, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("이미지 ID를 입력 받으면, DB에 저장된 이미지 URL을 반환해야 한다.")
+  void getFileUrl_success() {
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album title")
+        .summary("test album summary")
+        .type("test type")
+        .build();
+
+    AlbumImage mockAlbumImage = new AlbumImage();
+    mockAlbumImage.setId(101L);
+    mockAlbumImage.setUrl("https://fake.s3.amazonaws.com/test.jpg");
+    mockAlbumImage.setAlbum(mockAlbum);
+
+    when(albumImageRepository.findById(anyLong()))
+        .thenReturn(Optional.of(mockAlbumImage));
+
+    String url = awsS3Service.getFileUrl(mockAlbumImage.getId());
+
+    assertNotNull(url);
+    assertEquals("https://fake.s3.amazonaws.com/test.jpg", url);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 이미지 ID를 조회하면, IMAGE_NOT_FOUND 예외가 발생해야 한다.")
+  void getFileUrl_fail_image_not_found() {
+    // given
+    when(albumImageRepository.findById(anyLong()))
+        .thenReturn(Optional.empty());
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class,
+        () -> awsS3Service.getFileUrl(999L));
+
+    assertEquals(IMAGE_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("이미지 ID를 입력 받으면, 해당 사진을 삭제해야 한다.")
+  void deleteFile_success() {
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album title")
+        .summary("test album summary")
+        .type("test type")
+        .build();
+
+    AlbumImage mockAlbumImage = new AlbumImage();
+    mockAlbumImage.setId(101L);
+    mockAlbumImage.setUrl("https://fake.s3.amazonaws.com/test.jpg");
+    mockAlbumImage.setAlbum(mockAlbum);
+
+    when(albumImageRepository.findById(anyLong()))
+        .thenReturn(Optional.of(mockAlbumImage));
+
+    // when
+    awsS3Service.deleteFile(mockAlbumImage.getId());
+
+    // then
+    verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+    verify(albumImageRepository, times(1)).delete(mockAlbumImage);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 이미지 ID를 조회하면, IMAGE_NOT_FOUND 예외가 발생해야 한다.")
+  void deleteFile_fail_image_not_found() {
+    Long imageId = 333L;
+    when(albumImageRepository.findById(imageId)).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class, () -> awsS3Service.deleteFile(imageId));
+
+    assertEquals(IMAGE_NOT_FOUND, e.getErrorCode());
+    verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    verify(albumImageRepository, never()).delete(any(AlbumImage.class));
+  }
+
+  @Test
+  @DisplayName("S3 삭제 중 오류가 발생하면, FILE_DELETE_FAILED 예외가 발생해야 한다.")
+  void deleteFile_fail_file_delete_failed() {
+    Album mockAlbum = Album.builder()
+        .id(1L)
+        .title("test album title")
+        .summary("test album summary")
+        .type("test type")
+        .build();
+
+    AlbumImage mockAlbumImage = new AlbumImage();
+    mockAlbumImage.setId(101L);
+    mockAlbumImage.setUrl("https://fake.s3.amazonaws.com/test.jpg");
+    mockAlbumImage.setAlbum(mockAlbum);
+
+    when(albumImageRepository.findById(anyLong()))
+        .thenReturn(Optional.of(mockAlbumImage));
+
+    doThrow(new CustomException(FILE_DELETE_FAILED))
+        .when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+    // when & then
+    CustomException e = assertThrows(CustomException.class,
+        () -> awsS3Service.deleteFile(101L));
+
+    assertEquals(FILE_DELETE_FAILED, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- AWS S3 연동 미구현
- 사진 업로드, 조회, 삭제 기능 없음

**TO-BE**
- AWS S3 연동 및 사진 업로드/URL 조회/삭제 기능 구현
  - `AwsS3Config` 추가하여 S3 설정 적용
  - `AwsS3Service` 를 통해 사진 업로드, 조회, 삭제 기능 개발
  - `AwsS3Controller` 추가하여 API 제공
- 예외 처리 적용
  - `CustomException` 및 `ErrorCode` 정의
  - 사진 업로드, 조회, 삭제 시 발생할 수 있는 예외를 `CustomException` 으로 처리
- Swagger 설정 추가
  - Swagger UI를 통해 API 테스트 가능하도록 설정
- 단위 테스트 코드 작성
  - 사진 업로드, 조회, 삭제 기능 테스트 코드 추가 (`AwsS3ServiceTest`)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 (`AwsS3ServiceTest`)
- [x] API 테스트 (`Swagger 활용`)
